### PR TITLE
allow expires_in string type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1456,7 +1456,7 @@ export async function processPushedAuthorizationResponse(
     throw new OPE('"response" body "request_uri" property must be a non-empty string')
   }
 
-  if (typeof json.expires_in !== 'number' || json.expires_in <= 0) {
+  if ((typeof json.expires_in !== 'number' && typeof json.expires_in !== 'string') || parseInt(json.expires_in) <= 0) {
     throw new OPE('"response" body "expires_in" property must be a positive number')
   }
 


### PR DESCRIPTION
[naver provider](https://developers.naver.com/products/login/api/api.md)'s response is below.
```
{
  access_token: '...',
  refresh_token: '...',
  token_type: 'bearer',
  expires_in: '3600'
}
```
expires_in is a string type. so I modified a if condition that allow string type.